### PR TITLE
#3 サイドバーの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,18 @@ wp_enqueue_style( 'font-awesome', get_theme_file_uri( '/css/font-awesome.css' ),
 
 **カスタムメニュー**  
 https://www.webdesignleaves.com/pr/wp/wp_nav_menus.html  
+https://olein-design.com/blog/register-setting-souce-code-of-custom-menu  
 https://techmemo.biz/wordpress/wp-nav-menu-add-class/  
-	wp_nav_menu関数のパラメータに関しての記事。クラスの追加の仕方（2023/2/3)
+	wp_nav_menu関数のパラメータに関しての記事。クラスの追加の仕方（2023/2/3)  
+https://site-manage.net/archives/3346#_wp_footer  
+	謎の余白の原因→解決  
+http://dim5.net/wordpress/wp-nav-menu-container-delete.html  
+https://www.sejuku.net/blog/30092  
+	str_replaceについての記事  
+https://blog.webico.work/wp_nav_menu_sub  
+	sub-menuを変更する方法（これに伴い、もともとあった「p-gnavi__sub-menu__list」は「p-gnavi__submenu__list」に変更  
+
+
 
 
 ***

--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ get_theme_file_uriの書き方
 wp_enqueue_style( 'font-awesome', get_theme_file_uri( '/css/font-awesome.css' ), array(), '4.7.0' );  
 
 
-カスタムメニュー  
+**カスタムメニュー**  
 https://www.webdesignleaves.com/pr/wp/wp_nav_menus.html  
-
+https://techmemo.biz/wordpress/wp-nav-menu-add-class/  
+	wp_nav_menu関数のパラメータに関しての記事。クラスの追加の仕方（2023/2/3)
 
 
 ***

--- a/css/style.css
+++ b/css/style.css
@@ -875,10 +875,6 @@ https://daib-log.com/responsive/
     display: block;
   }
 }
-.p-gnavi h3 {
-  font-size: 2.4rem;
-  font-weight: 700;
-}
 .p-gnavi__main-menu {
   /* SP基準--tablet-- */
   /* SP基準--PC-- */
@@ -892,17 +888,20 @@ https://daib-log.com/responsive/
 }
 .p-gnavi__main-menu__list {
   margin-top: 38px;
+  font-size: 2.4rem;
+  font-weight: 700;
 }
 .p-gnavi__main-menu__list:first-of-type {
   margin-top: 138px;
 }
-.p-gnavi .p-gnavi__sub-menu {
+.p-gnavi .p-gnavi__submenu {
   margin-top: 40px;
 }
-.p-gnavi .p-gnavi__sub-menu__list {
+.p-gnavi .p-gnavi__submenu__list {
   margin-top: 22px;
   margin-left: 20px;
   font-size: 2rem;
+  font-weight: 400;
 }
 
 .p-place {

--- a/functions.php
+++ b/functions.php
@@ -54,9 +54,11 @@
 
 	// カスタムメニュー
 	function register_my_menus() { 
-		register_nav_menus( array( //複数のナビゲーションメニューを登録する関数
+		register_nav_menus( array( // 複数のナビゲーションメニューを登録する関数
 			//'「メニューの位置」の識別子' => 'メニューの説明の文字列',
 			'category_nav' => 'カテゴリーナビゲーション',
+			//'menu_nav' => 'メニューナビゲーション',
+			'footer_nav' => 'フッターナビゲーション',
 		) );
 	}
 	add_action( 'after_setup_theme', 'register_my_menus' );

--- a/scss/object/project/_gnavi.scss
+++ b/scss/object/project/_gnavi.scss
@@ -17,10 +17,10 @@
 		}
 	}
 	// メインメニュー
-	h3{
-		font-size: 2.4rem;
-		font-weight: 700;
-	}
+	// h3{
+	// 	font-size: 2.4rem;
+	// 	font-weight: 700;
+	// }
 	&__main-menu{
 	// .p-gnavi__main-menu{
 		@include mixin.breakpoint ( breakpoint-medium ){
@@ -31,13 +31,15 @@
 		// li{
 		&__list{
 			margin-top: 38px;
+			font-size: 2.4rem;
+			font-weight: 700;
 			&:first-of-type{
 				// margin-top: 212px;
 				margin-top: 138px;
 			}
 		}
 	}
-	.p-gnavi__sub-menu{
+	.p-gnavi__submenu{
 		margin-top: 40px;   // main-menuとの余白設定
 		&__list{
 			margin-top: 22px;
@@ -45,6 +47,7 @@
 			margin-left: 20px;
 			// margin-bottom: 40px;
 			font-size: 2rem;
+			font-weight: 400;
 		}
 	}
 }

--- a/sidebar.php
+++ b/sidebar.php
@@ -5,18 +5,19 @@
 	<button type="button" class="c-button--close c-button--js"></button><!--このbuttonタグはnavタグ内に入れたほうがいいのか？？？-->
 	<nav class="p-gnavi">
 		<h2>Menu</h2>
-		<ul class="p-gnavi__main-menu">
-			<li class="p-gnavi__main-menu__list"><h3>バーガー</h3>
-				<ul class="p-gnavi__sub-menu">
-					<li class="p-gnavi__sub-menu__list"><a href="#">ハンバーガー</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">チーズバーガー</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">テリヤキバーガー</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">アボカドバーガー</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">フィッシュバーガー</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">ベーコンバーガー</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">チキンバーガー</a></li>
-				</ul>
-			</li>
+		<?php
+		$defaults = array(
+			'menu' => 'category_nav',	//メニューを指定
+			'menu_class' => 'p-gnavi__main-menu'
+			
+
+		);
+		wp_nav_menu( $defaults );
+		?>
+
+
+
+<!--
 			<li class="p-gnavi__main-menu__list"><h3>サイド</h3>
 				<ul class="p-gnavi__sub-menu">
 					<li class="p-gnavi__sub-menu__list"><a href="#">ポテト</a></li>
@@ -34,7 +35,7 @@
 					<li class="p-gnavi__sub-menu__list"><a href="#">紅茶（Ice/Hot）</a></li>
 					<li class="p-gnavi__sub-menu__list"><a href="#">コーヒー（Ice/Hot）</a></li>
 				</ul>
-			</li>
 		</ul>
+			-->
 	</nav>
 </aside><!-- /.l-sidebar -->

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,41 +1,19 @@
 <!-- <article class="l-sidebar"><article>タグは、内容が単体で完結するセクションであることを示す際に使用 -->
 <aside class="l-sidebar"><!-- <aside>タグは、メインコンテンツとは直接関係のない、複数ページ共通のコンテンツ用の要素 -->
-
-
 	<button type="button" class="c-button--close c-button--js"></button><!--このbuttonタグはnavタグ内に入れたほうがいいのか？？？-->
 	<nav class="p-gnavi">
 		<h2>Menu</h2>
 		<?php
-		$defaults = array(
-			'menu' => 'category_nav',	//メニューを指定
-			'menu_class' => 'p-gnavi__main-menu'
-			
-
-		);
-		wp_nav_menu( $defaults );
+			echo str_replace(
+				'sub-menu', 'p-gnavi__submenu',// 引数:$検索文字列 , $置換後文字列 , $検索対象文字列 [, int &$count ] )
+				wp_nav_menu( array(
+					'menu'			=> 'category_nav',			// メニューを指定
+					'menu_class'	=> 'p-gnavi__main-menu',
+					'container'		=> false,					// ulを囲う要素を指定。div or nav。なしの場合には false
+					'echo'			=> false,					//（真偽値） （オプション） メニューをHTML出力する(true)か、PHPの値で返す(false)か 初期値： true
+					)
+				)
+			);
 		?>
-
-
-
-<!--
-			<li class="p-gnavi__main-menu__list"><h3>サイド</h3>
-				<ul class="p-gnavi__sub-menu">
-					<li class="p-gnavi__sub-menu__list"><a href="#">ポテト</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">サラダ</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">ナゲット</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">コーン</a></li>
-				</ul>
-			</li>
-			<li class="p-gnavi__main-menu__list"><h3>ドリンク</h3>
-				<ul class="p-gnavi__sub-menu">
-					<li class="p-gnavi__sub-menu__list"><a href="#">コーラ</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">ファンタ</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">オレンジ</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">アップル</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">紅茶（Ice/Hot）</a></li>
-					<li class="p-gnavi__sub-menu__list"><a href="#">コーヒー（Ice/Hot）</a></li>
-				</ul>
-		</ul>
-			-->
 	</nav>
 </aside><!-- /.l-sidebar -->

--- a/single.php
+++ b/single.php
@@ -134,43 +134,7 @@
 			</section><!-- </.p-single> -->
 		</main><!-- /.p-main -->
 		<!-- <article class="l-sidebar"><article>タグは、内容が単体で完結するセクションであることを示す際に使用 -->
-		<aside class="l-sidebar"><!-- <aside>タグは、メインコンテンツとは直接関係のない、複数ページ共通のコンテンツ用の要素 -->
-			<button type="button" class="c-button--close c-button--js"></button><!--このbuttonタグはnavタグ内に入れたほうがいいのか？？？-->
-			<nav class="p-gnavi">
-				<h2>Menu</h2>
-				<ul class="p-gnavi__main-menu">
-					<li class="p-gnavi__main-menu__list"><h3>バーガー</h3>
-						<ul class="p-gnavi__sub-menu">
-							<li class="p-gnavi__sub-menu__list"><a href="#">ハンバーガー</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">チーズバーガー</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">テリヤキバーガー</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">アボカドバーガー</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">フィッシュバーガー</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">ベーコンバーガー</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">チキンバーガー</a></li>
-						</ul>
-					</li>
-					<li class="p-gnavi__main-menu__list"><h3>サイド</h3>
-						<ul class="p-gnavi__sub-menu">
-							<li class="p-gnavi__sub-menu__list"><a href="#">ポテト</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">サラダ</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">ナゲット</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">コーン</a></li>
-						</ul>
-					</li>
-					<li class="p-gnavi__main-menu__list"><h3>ドリンク</h3>
-						<ul class="p-gnavi__sub-menu">
-							<li class="p-gnavi__sub-menu__list"><a href="#">コーラ</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">ファンタ</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">オレンジ</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">アップル</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">紅茶（Ice/Hot）</a></li>
-							<li class="p-gnavi__sub-menu__list"><a href="#">コーヒー（Ice/Hot）</a></li>
-						</ul>
-					</li>
-				</ul>
-			</nav>
-		</aside><!-- /.l-sidebar -->
+		<?php get_sidebar(); ?> <!-- siderbar.phpを読み込むテンプレートタグ（インクルードタグ） -->
 	</div><!-- /.l-container -->
 
 	<footer class="l-footer">


### PR DESCRIPTION
wp_nav_menu()で実装。
自動付与される「sub-menu」をstr_replaceで置換するも、「p-gnavi__sub-menu__list」が「p-gnavi__p-gnavi__sub-menu__list」になってしまうため、「p-gnavi__submenu__list」に修正変更。
「p-gnavi__main-menu__list」に「h3」のフォント指定を移し、p-gnavi__submenu__listでは上書きして太さを変更。
サイドバーを使用するphpファイルを呼び出すコードに修正。