### PR TITLE
対象ファイルの見出し表示をthe_title()に変更。他、テーマチェック推奨項目に対しての修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,6 +48,52 @@ cite {
   font-style: normal;
 }
 
+.wp-caption {
+  margin: auto;
+  text-align: center;
+  max-width: 100%;
+}
+
+.wp-caption-text {
+  display: inline-block;
+  text-align: left;
+  margin: 10px 0 0;
+}
+
+/* Text meant only for screen readers. */
+.screen-reader-text {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+          clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+}
+
+.screen-reader-text:focus {
+  background-color: #eee;
+  clip: auto !important;
+  -webkit-clip-path: none;
+          clip-path: none;
+  color: #444;
+  display: block;
+  font-size: 1em;
+  height: auto;
+  left: 5px;
+  line-height: normal;
+  padding: 15px 23px 14px;
+  text-decoration: none;
+  top: 5px;
+  width: auto;
+  z-index: 100000;
+  /* Above WP toolbar. */
+}
+
 /*----------------------------------------------------------
 ◆SmartPhone  : 320px〜540px
 	iPhone 12mini   : 5.4インチ、375 × 667
@@ -1677,35 +1723,4 @@ https://daib-log.com/responsive/
 
 .u-margintop20 {
   margin-top: 20px;
-}
-/* Text meant only for screen readers. */
-.screen-reader-text {
-  border: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
-}
-
-.screen-reader-text:focus {
-  background-color: #eee;
-  clip: auto !important;
-  clip-path: none;
-  color: #444;
-  display: block;
-  font-size: 1em;
-  height: auto;
-  left: 5px;
-  line-height: normal;
-  padding: 15px 23px 14px;
-  text-decoration: none;
-  top: 5px;
-  width: auto;
-  z-index: 100000;
-  /* Above WP toolbar. */
 }

--- a/page.php
+++ b/page.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>  <!-- header.phpを読み込むテンプレートタグ（インクルードタグ） -->
 	<main class="p-main">
 		<article id="top" class="p-first-view--page">
-			<h1><?php echo wp_get_document_title(); ?></h1>
+			<?php echo the_title('<h1>', '</h1>'); ?>
 		</article><!-- /.p-main__first-view--page -->
 		<section class="p-single">
 		<?php

--- a/scss/foundation/_base.scss
+++ b/scss/foundation/_base.scss
@@ -51,3 +51,47 @@ fieldset{
 cite{
 	font-style: normal; // 斜体
 }
+
+// 以下、テーマチェックによる推奨・情報に関する記述
+.wp-caption {
+	margin: auto;
+	text-align: center;
+	max-width: 100%;
+}
+.wp-caption-text {
+	display: inline-block;
+	text-align: left;
+	margin: 10px 0 0;
+}
+
+/* Text meant only for screen readers. */
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+}
+
+.screen-reader-text:focus {
+	background-color: #eee;
+	clip: auto !important;
+	clip-path: none;
+	color: #444;
+	display: block;
+	font-size: 1em;
+	height: auto;
+	left: 5px;
+	line-height: normal;
+	padding: 15px 23px 14px;
+	text-decoration: none;
+	top: 5px;
+	width: auto;
+	z-index: 100000;
+	/* Above WP toolbar. */
+}

--- a/single.php
+++ b/single.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>  <!-- header.phpを読み込むテンプレートタグ（インクルードタグ） -->
 		<main class="p-main">
 			<article id="top" class="p-first-view--single">
-				<h1><?php echo wp_get_document_title(); ?></h1>
+				<?php echo the_title('<h1>', '</h1>'); ?>
 			</article><!-- /.p-main__first-view--single -->
 			<section class="p-single">
 			<?php


### PR DESCRIPTION
page.php, single.php の見出し取得を、the_title()に変更。

> pre_get_document_title のフックを使ってtitleタグの書き換えをする場合、wp_get_document_title() で出力される文字列にも影響が出てしまう。

テーマチェックで推奨項目のいくつかを修正。
base.scssに追記することにした。